### PR TITLE
prevents false $translateChangeSuccess events

### DIFF
--- a/src/service/translate.js
+++ b/src/service/translate.js
@@ -1113,6 +1113,9 @@ function $translate($STORAGE_KEY, $windowProvider, $translateSanitizationProvide
        * @param {key} Locale key.
        */
       var useLanguage = function (key) {
+        if ($uses === key)
+          return;
+          
         $uses = key;
 
         // make sure to store new language key before triggering success event


### PR DESCRIPTION
Allows propagating of event $translateChangeSuccess only when the language has changed.
This is useful in cases applications have to do more than just download translations, like for example refresh some webservice information on language change.